### PR TITLE
feat(deps): Remove [cli] option in favor of making it a requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,27 +13,27 @@ Note that this repository and corresponding Python package does not contain any
 code and it simply exists to provide a shortcut for installing all of the honeybee
 core libraries together.
 
-## Included Honeybee Packages
+## Included Honeybee Extensions
 
 Running `pip install lbt-honeybee` will result in the installation of the following
 honeybee Python packages:
 
-* [honeybee-core](https://github.com/ladybug-tools/honeybee-core)
 * [honeybee-radiance](https://github.com/ladybug-tools/honeybee-radiance)
 * [honeybee-radiance-folder](https://github.com/ladybug-tools/honeybee-radiance-folder)
 * [honeybee-radiance-command](https://github.com/ladybug-tools/honeybee-radiance-command)
 * [honeybee-energy](https://github.com/ladybug-tools/honeybee-energy)
 * [honeybee-energy-standards](https://github.com/ladybug-tools/honeybee-energy-standards)
 
+## Included Honeybee Core Libraries
+
+Since both honeybee extensions use the honeybee core libraries, the following
+dependencies are also included:
+
+* [honeybee-core](https://github.com/ladybug-tools/honeybee-core)
+* [honeybee-schema](https://github.com/ladybug-tools/honeybee-schema)
+
 ## All Ladybug Packages Are Also Included
 
 Since honeybee uses ladybug, the following is also included:
 
 * [lbt-ladybug](https://github.com/ladybug-tools/lbt-ladybug)
-
-## The CLI option
-
-Running `pip install lbt-honeybee[cli]` will ensure that all dependencies for the
-command line interfaces (CLI) are also installed, including:
-
-* [honeybee-schema](https://github.com/ladybug-tools/honeybee-schema)

--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,6 @@ setuptools.setup(
     url="https://github.com/ladybug-tools/lbt-honeybee",
     packages=setuptools.find_packages(),
     install_requires=requirements,
-    extras_require={
-        'cli': ['click==7.1.2', "honeybee-schema==1.42.0;python_version>='3.6'"]
-    },
     classifiers=[
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.6",


### PR DESCRIPTION
The [cli] option is now redundant given that the other core libraries already contain the dependencies.