### PR TITLE
feat(docker): Setup auto-deployment to Dockerhub

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.dependabot
+.github
+
+Dockerfile

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,3 +45,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
           PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -6,7 +6,7 @@
         [
             "@semantic-release/exec",
             {
-                "publishCmd": "bash deploy.sh"
+                "publishCmd": "bash deploy.sh ${nextRelease.version}"
             }
         ]
     ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.7
+
+LABEL maintainer="Ladybug Tools" email="info@ladybug.tools"
+
+# Create non-root user
+RUN adduser ladybugbot --uid 1000
+USER ladybugbot
+WORKDIR /home/ladybugbot
+RUN mkdir ladybug_tools && touch ladybug_tools/config.json
+
+
+# Install lbt-honeybee
+ENV PATH="/home/ladybugbot/.local/bin:${PATH}"
+COPY . lbt-honeybee
+RUN pip3 install setuptools wheel\
+    && pip3 install ./lbt-honeybee
+
+# Set up working directory
+RUN mkdir -p /home/ladybugbot/run/simulation
+WORKDIR /home/ladybugbot/run

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,6 +1,28 @@
 #!/bin/sh
 
+if [ -n "$1" ]
+then
+  NEXT_RELEASE_VERSION=$1
+else
+  echo "A release version must be supplied"
+  exit 1
+fi
+
+CONTAINER_NAME="ladybugtools/lbt-honeybee"
+
+echo "PyPi Deployment..."
 echo "Building distribution"
 python setup.py sdist bdist_wheel
 echo "Pushing new version to PyPi"
 twine upload dist/* -u $PYPI_USERNAME -p $PYPI_PASSWORD
+
+
+echo "Docker Deployment..."
+echo "Login to Docker"
+echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+
+docker build . -t $CONTAINER_NAME:$NEXT_RELEASE_VERSION 
+docker tag $CONTAINER_NAME:$NEXT_RELEASE_VERSION $CONTAINER_NAME:latest
+
+docker push $CONTAINER_NAME:latest
+docker push $CONTAINER_NAME:$NEXT_RELEASE_VERSION


### PR DESCRIPTION
This docker image will be needed for cases where one needs access to multiple extensions - like a command to assign the attributes of one simulation engine based on another.